### PR TITLE
Fix IQA link

### DIFF
--- a/views/layout.haml
+++ b/views/layout.haml
@@ -9,7 +9,7 @@
             #{@layout['irdp']} 
             + 
         %li.no-kids.iqa
-          %a{href: 'http://iqaquidditch.org/', target: '_blank'}<
+          %a{href: 'http://iqasport.com/', target: '_blank'}<
             -# %img.logo{src: 'images/iqa-logo.jpg'}
             IQA
         %li


### PR DESCRIPTION
To remove the link to the old-now-scam website.